### PR TITLE
fix: Add GitHub Actions permissions for parallel workflow

### DIFF
--- a/.github/workflows/travel_monitor.yml
+++ b/.github/workflows/travel_monitor.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   monitor:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:
@@ -95,9 +97,15 @@ jobs:
   generate-landing:
     needs: monitor
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
- Add contents: write permission for generate-landing job
- Add pages: write and id-token: write permissions
- Add GITHUB_TOKEN to checkout action
- Fix 403 permission denied error when pushing changes

This allows the parallel workflow to successfully commit and push generated dashboards and data updates to the repository.