### PR TITLE
Add Turkey 7–10 and 13–16 day filters with grouped navigation.

### DIFF
--- a/.github/workflows/travel_monitor_sequential.yml
+++ b/.github/workflows/travel_monitor_sequential.yml
@@ -69,6 +69,8 @@ jobs:
 
           python travel_monitor.py --config config_ci_filter_7_10.json
           python travel_monitor.py --config config_ci_filter_13_16.json
+          python travel_monitor.py --config config_ci_filter_turkey_7_10.json
+          python travel_monitor.py --config config_ci_filter_turkey_13_16.json
 
           echo "✅ Monitoring completed"
 
@@ -79,7 +81,7 @@ jobs:
           python generate_inline_charts_dashboard.py \
             --data-file data/filters/filter_7_10_days/travel_prices.csv \
             --output index_filter_7_10_days.html \
-            --title "Мониторинг цен • Фильтр 7–10 дней" \
+            --title "Мониторинг цен • Египет • 7–10 дней" \
             --charts-dir hotel-charts/filter_7_10_days \
             --alerts-file data/filters/filter_7_10_days/travel_prices_alerts.json \
             --display-price-ceiling 10000 \
@@ -88,9 +90,27 @@ jobs:
           python generate_inline_charts_dashboard.py \
             --data-file data/filters/filter_13_16_days/travel_prices.csv \
             --output index_filter_13_16_days.html \
-            --title "Мониторинг цен • Фильтр 13–16 дней" \
+            --title "Мониторинг цен • Египет • 13–16 дней" \
             --charts-dir hotel-charts/filter_13_16_days \
             --alerts-file data/filters/filter_13_16_days/travel_prices_alerts.json \
+            --display-price-ceiling 10000 \
+            --history-price-ceiling 20000
+
+          python generate_inline_charts_dashboard.py \
+            --data-file data/filters/filter_turkey_7_10_days/travel_prices.csv \
+            --output index_filter_turkey_7_10_days.html \
+            --title "Мониторинг цен • Турция • 7–10 дней" \
+            --charts-dir hotel-charts/filter_turkey_7_10_days \
+            --alerts-file data/filters/filter_turkey_7_10_days/travel_prices_alerts.json \
+            --display-price-ceiling 10000 \
+            --history-price-ceiling 20000
+
+          python generate_inline_charts_dashboard.py \
+            --data-file data/filters/filter_turkey_13_16_days/travel_prices.csv \
+            --output index_filter_turkey_13_16_days.html \
+            --title "Мониторинг цен • Турция • 13–16 дней" \
+            --charts-dir hotel-charts/filter_turkey_13_16_days \
+            --alerts-file data/filters/filter_turkey_13_16_days/travel_prices_alerts.json \
             --display-price-ceiling 10000 \
             --history-price-ceiling 20000
 
@@ -110,9 +130,13 @@ jobs:
           cp -f index.html site/index.html
           cp -f index_filter_7_10_days.html site/index_filter_7_10_days.html
           cp -f index_filter_13_16_days.html site/index_filter_13_16_days.html
+          cp -f index_filter_turkey_7_10_days.html site/index_filter_turkey_7_10_days.html
+          cp -f index_filter_turkey_13_16_days.html site/index_filter_turkey_13_16_days.html
 
           cp -R hotel-charts/filter_7_10_days site/hotel-charts/ || true
           cp -R hotel-charts/filter_13_16_days site/hotel-charts/ || true
+          cp -R hotel-charts/filter_turkey_7_10_days site/hotel-charts/ || true
+          cp -R hotel-charts/filter_turkey_13_16_days site/hotel-charts/ || true
 
           cp -R data/filters site/data/ || true
 
@@ -143,8 +167,8 @@ jobs:
           
           # Добавляем только данные/страницы новых фильтров
           git add -f data/filters/ || true
-          git add index.html index_filter_7_10_days.html index_filter_13_16_days.html || true
-          git add -f hotel-charts/filter_7_10_days/ hotel-charts/filter_13_16_days/ || true
+          git add index.html index_filter_7_10_days.html index_filter_13_16_days.html index_filter_turkey_7_10_days.html index_filter_turkey_13_16_days.html || true
+          git add -f hotel-charts/filter_7_10_days/ hotel-charts/filter_13_16_days/ hotel-charts/filter_turkey_7_10_days/ hotel-charts/filter_turkey_13_16_days/ || true
           
           # Проверяем, есть ли изменения для коммита
           if git diff --staged --quiet; then
@@ -154,8 +178,10 @@ jobs:
             COMMIT_MSG="🔄 Hourly update (only new filters) - $(date '+%Y-%m-%d %H:%M:%S UTC')
 
             📌 Filters:
-            - 7–10 days (scrape 4000–20000 PLN, show ≤10000)
-            - 13–16 days (scrape 4000–20000 PLN, show ≤10000)
+            - Egypt 7–10 days (scrape 4000–20000 PLN, show ≤10000)
+            - Egypt 13–16 days (scrape 4000–20000 PLN, show ≤10000)
+            - Turkey 7–10 days (scrape 4000–20000 PLN, show ≤10000)
+            - Turkey 13–16 days (scrape 4000–20000 PLN, show ≤10000)
 
             🤖 Automated by GitHub Actions"
             
@@ -176,7 +202,9 @@ jobs:
 
           echo "### 🔗 Links" >> $GITHUB_STEP_SUMMARY
           echo "- [Landing](https://andreiYank.github.io/travel-monitoring/)" >> $GITHUB_STEP_SUMMARY
-          echo "- [Filter 7–10 days](https://andreiYank.github.io/travel-monitoring/index_filter_7_10_days.html)" >> $GITHUB_STEP_SUMMARY
-          echo "- [Filter 13–16 days](https://andreiYank.github.io/travel-monitoring/index_filter_13_16_days.html)" >> $GITHUB_STEP_SUMMARY
+          echo "- [Egypt 7–10 days](https://andreiYank.github.io/travel-monitoring/index_filter_7_10_days.html)" >> $GITHUB_STEP_SUMMARY
+          echo "- [Egypt 13–16 days](https://andreiYank.github.io/travel-monitoring/index_filter_13_16_days.html)" >> $GITHUB_STEP_SUMMARY
+          echo "- [Turkey 7–10 days](https://andreiYank.github.io/travel-monitoring/index_filter_turkey_7_10_days.html)" >> $GITHUB_STEP_SUMMARY
+          echo "- [Turkey 13–16 days](https://andreiYank.github.io/travel-monitoring/index_filter_turkey_13_16_days.html)" >> $GITHUB_STEP_SUMMARY
           echo "- [View Data](https://github.com/AndreiYank/travel-monitoring/tree/main/data/filters)" >> $GITHUB_STEP_SUMMARY
           echo "- [View Logs](https://github.com/AndreiYank/travel-monitoring/actions/runs/${{ github.run_id }})" >> $GITHUB_STEP_SUMMARY

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,8 @@ index_*.html
 
 # Legacy one-off observation runs (egypt_8/turkey_8 configs → data_runs/)
 /data_runs/
+
+# Local scrape / dashboard regen for Turkey filters (CI force-adds after deploy)
+data/filters/filter_turkey_7_10_days/
+data/filters/filter_turkey_13_16_days/
+

--- a/config_ci_filter_turkey_13_16.json
+++ b/config_ci_filter_turkey_13_16.json
@@ -1,0 +1,23 @@
+{
+  "url": "https://fly.pl/oferta/turcja-wczasy/?filter[dest]=39:&filter[hotelids]=&filter[cityids]=&filter[cregids]=&filter[ofrType]=&filter[addObjType]=H&filter[whenFrom]=31-05-2026&filter[whenTo]=30-06-2026&filter[duration]=13:16&filter[from]=Warszawa,Warszawa%20-%20Radom&filter[person]=2&filter[child]=1&filter[price]=4000:20000&filter[PriceFrom]=4000&filter[PriceTo]=20000&filter[addCategory]=50&filter[addCatering]=0&filter[addMisc]=0&filter[addTransport]=F&filter[fp]=1&order_by=ofr_price&filter[tourOperator]=0&filter[childAge][1]=20201210",
+  "max_price_threshold": 20000,
+  "min_price_threshold": 4000,
+  "required_offer_url_contains": [
+    "/wycieczka/turcja",
+    "transport=accommodation_flight"
+  ],
+  "excluded_offer_url_contains": [
+    "/wycieczka/polska",
+    "/wycieczka/czechy",
+    "transport=accommodation&"
+  ],
+  "wait_timeout": 30000,
+  "max_retries": 3,
+  "max_offers": 0,
+  "max_pages": 10,
+  "display_price_ceiling": 10000,
+  "retry_delay": 5,
+  "data_dir": "data/filters/filter_turkey_13_16_days",
+  "output_data_file": "travel_prices.csv",
+  "description": "CI filter • Турция • 13-16 дней • сбор 4000-20000 PLN, показ ≤10000"
+}

--- a/config_ci_filter_turkey_7_10.json
+++ b/config_ci_filter_turkey_7_10.json
@@ -1,0 +1,23 @@
+{
+  "url": "https://fly.pl/oferta/turcja-wczasy/?filter[dest]=39:&filter[hotelids]=&filter[cityids]=&filter[cregids]=&filter[ofrType]=&filter[addObjType]=H&filter[whenFrom]=31-05-2026&filter[whenTo]=30-06-2026&filter[duration]=7:10&filter[from]=Warszawa,Warszawa%20-%20Radom&filter[person]=2&filter[child]=1&filter[price]=4000:20000&filter[PriceFrom]=4000&filter[PriceTo]=20000&filter[addCategory]=50&filter[addCatering]=0&filter[addMisc]=0&filter[addTransport]=F&filter[fp]=1&order_by=ofr_price&filter[tourOperator]=0&filter[childAge][1]=20201210",
+  "max_price_threshold": 20000,
+  "min_price_threshold": 4000,
+  "required_offer_url_contains": [
+    "/wycieczka/turcja",
+    "transport=accommodation_flight"
+  ],
+  "excluded_offer_url_contains": [
+    "/wycieczka/polska",
+    "/wycieczka/czechy",
+    "transport=accommodation&"
+  ],
+  "wait_timeout": 30000,
+  "max_retries": 3,
+  "max_offers": 0,
+  "max_pages": 10,
+  "display_price_ceiling": 10000,
+  "retry_delay": 5,
+  "data_dir": "data/filters/filter_turkey_7_10_days",
+  "output_data_file": "travel_prices.csv",
+  "description": "CI filter • Турция • 7-10 дней • сбор 4000-20000 PLN, показ ≤10000"
+}

--- a/filter_registry.py
+++ b/filter_registry.py
@@ -1,0 +1,68 @@
+"""Shared filter list for landing page and dashboard sidebar."""
+
+FILTER_GROUPS = [
+    {
+        'id': 'egypt',
+        'label': 'Египет',
+        'icon': '🇪🇬',
+        'filters': [
+            {
+                'id': 'egypt_7_10',
+                'title': '7–10 дней',
+                'subtitle': 'сбор 4–20k PLN • показ ≤10k • WAW/WMI/RDO',
+                'href': 'index_filter_7_10_days.html',
+                'charts_subdir': 'hotel-charts/filter_7_10_days',
+            },
+            {
+                'id': 'egypt_13_16',
+                'title': '13–16 дней',
+                'subtitle': 'сбор 4–20k PLN • показ ≤10k • WAW/WMI/RDO',
+                'href': 'index_filter_13_16_days.html',
+                'charts_subdir': 'hotel-charts/filter_13_16_days',
+            },
+        ],
+    },
+    {
+        'id': 'turkey',
+        'label': 'Турция',
+        'icon': '🇹🇷',
+        'filters': [
+            {
+                'id': 'turkey_7_10',
+                'title': '7–10 дней',
+                'subtitle': 'сбор 4–20k PLN • показ ≤10k • WAW/RDO',
+                'href': 'index_filter_turkey_7_10_days.html',
+                'charts_subdir': 'hotel-charts/filter_turkey_7_10_days',
+            },
+            {
+                'id': 'turkey_13_16',
+                'title': '13–16 дней',
+                'subtitle': 'сбор 4–20k PLN • показ ≤10k • WAW/RDO',
+                'href': 'index_filter_turkey_13_16_days.html',
+                'charts_subdir': 'hotel-charts/filter_turkey_13_16_days',
+            },
+        ],
+    },
+]
+
+
+def iter_filters():
+    for group in FILTER_GROUPS:
+        for flt in group['filters']:
+            yield group, flt
+
+
+def filter_href_by_charts_subdir(charts_subdir: str) -> str:
+    sub = (charts_subdir or '').rstrip('/')
+    for _, flt in iter_filters():
+        if flt['charts_subdir'].rstrip('/') == sub:
+            return flt['href']
+    return 'index.html'
+
+
+def active_filter_id(charts_subdir: str) -> str:
+    sub = (charts_subdir or '').rstrip('/')
+    for _, flt in iter_filters():
+        if flt['charts_subdir'].rstrip('/') == sub:
+            return flt['id']
+    return ''

--- a/generate_inline_charts_dashboard.py
+++ b/generate_inline_charts_dashboard.py
@@ -12,6 +12,7 @@ import re
 import html as html_lib
 from urllib.parse import urlparse, parse_qs
 from purchase_timing_analysis import analyze_purchase_timing
+from filter_registry import FILTER_GROUPS, active_filter_id, filter_href_by_charts_subdir
 
 
 def _parse_price_ceiling(display_price_ceiling):
@@ -2081,12 +2082,7 @@ def generate_inline_charts_dashboard(data_file: str = 'data/travel_prices.csv', 
         hotel_html_path = os.path.join(charts_dir, f"{hotel_slug}.html")
 
         subdir = (charts_subdir or '').rstrip('/')
-        if subdir.endswith('filter_7_10_days'):
-            back_target = 'index_filter_7_10_days.html'
-        elif subdir.endswith('filter_13_16_days'):
-            back_target = 'index_filter_13_16_days.html'
-        else:
-            back_target = 'index.html'
+        back_target = filter_href_by_charts_subdir(subdir)
         back_href = os.path.relpath(back_target, start=os.path.dirname(hotel_html_path))
 
         meta = hotel_meta_by_name.get(hotel_name, {})
@@ -2271,6 +2267,28 @@ def generate_inline_charts_dashboard(data_file: str = 'data/travel_prices.csv', 
         updated_str = df['scraped_at_display'].max().strftime('%d.%m.%Y %H:%M')
     except Exception:
         updated_str = datetime.now().strftime('%d.%m.%Y %H:%M')
+
+    _current_filter = active_filter_id(charts_subdir)
+    _sidebar_nav_parts = [
+        '<a href="index.html" class="nav-item">'
+        '<span class="flag">🏠</span>'
+        '<div><div class="country-name">Главная</div>'
+        '<div class="country-desc">Выбор направления</div></div></a>'
+    ]
+    for group in FILTER_GROUPS:
+        _sidebar_nav_parts.append(
+            f'<div class="nav-group-label"><span>{group["icon"]}</span>{group["label"]}</div>'
+        )
+        for flt in group['filters']:
+            active = ' active' if flt['id'] == _current_filter else ''
+            icon = '📅' if flt['title'].startswith('7') else '📆'
+            _sidebar_nav_parts.append(
+                f'<a href="{flt["href"]}" class="nav-item{active}">'
+                f'<span class="flag">{icon}</span>'
+                f'<div><div class="country-name">{flt["title"]}</div>'
+                f'<div class="country-desc">{group["label"]}</div></div></a>'
+            )
+    sidebar_nav_html = ''.join(_sidebar_nav_parts)
 
     html_template = f"""<!DOCTYPE html>
 <html lang="ru">
@@ -4069,6 +4087,18 @@ def generate_inline_charts_dashboard(data_file: str = 'data/travel_prices.csv', 
             border-radius: 0 12px 12px 0;
             margin: 2px 8px 2px 0;
         }}
+
+        .nav-group-label {{
+            padding: .85rem 1.5rem .35rem;
+            font-size: .68rem;
+            font-weight: 800;
+            letter-spacing: .08em;
+            text-transform: uppercase;
+            color: #94a3b8;
+            display: flex;
+            align-items: center;
+            gap: .4rem;
+        }}
         
         .nav-item:hover {{
             background: rgba(79,70,229,.08);
@@ -4394,27 +4424,7 @@ def generate_inline_charts_dashboard(data_file: str = 'data/travel_prices.csv', 
             <h2>🌍 Travel Monitor</h2>
         </div>
         <nav class="sidebar-nav">
-            <a href="index.html" class="nav-item">
-                <span class="flag">🏠</span>
-                <div>
-                    <div class="country-name">Главная</div>
-                    <div class="country-desc">Выбор фильтра</div>
-                </div>
-            </a>
-            <a href="index_filter_7_10_days.html" class="nav-item {'active' if '7' in title and '10' in title else ''}">
-                <span class="flag">📅</span>
-                <div>
-                    <div class="country-name">Фильтр 7–10 дней</div>
-                    <div class="country-desc">Актуальные предложения</div>
-                </div>
-            </a>
-            <a href="index_filter_13_16_days.html" class="nav-item {'active' if '13' in title and '16' in title else ''}">
-                <span class="flag">📆</span>
-                <div>
-                    <div class="country-name">Фильтр 13–16 дней</div>
-                    <div class="country-desc">Актуальные предложения</div>
-                </div>
-            </a>
+            {sidebar_nav_html}
         </nav>
     </div>
     

--- a/generate_landing.py
+++ b/generate_landing.py
@@ -1,20 +1,46 @@
 #!/usr/bin/env python3
 import datetime
 
-def generate_landing(tiles, output_file='index.html'):
+from filter_registry import FILTER_GROUPS
+
+
+def generate_landing(tiles=None, output_file='index.html'):
     now = datetime.datetime.now().strftime('%d.%m.%Y %H:%M')
-    cards_count = len(tiles)
-    cards_html = "".join([
-        f"""
-        <a class=\"card\" href=\"{t['href']}\">\n  <div class=\"card-body\">\n    <div class=\"card-title\">{t['title']}</div>\n    <div class=\"card-sub\">{t.get('subtitle','')}</div>\n    <div class=\"card-action\">Открыть дашборд →</div>\n  </div>\n</a>
-        """ for t in tiles
-    ])
+    if tiles is None:
+        tiles = FILTER_GROUPS
+
+    cards_count = sum(len(g['filters']) for g in tiles)
+    sections_html = []
+    for group in tiles:
+        cards_html = "".join([
+            f"""
+        <a class="card" href="{flt['href']}">
+          <div class="card-body">
+            <div class="card-title">{flt['title']}</div>
+            <div class="card-sub">{flt.get('subtitle', '')}</div>
+            <div class="card-action">Открыть дашборд →</div>
+          </div>
+        </a>
+            """ for flt in group['filters']
+        ])
+        sections_html.append(f"""
+    <section class="filter-section">
+      <div class="section-head">
+        <span class="section-icon">{group.get('icon', '')}</span>
+        <h2 class="section-title">{group['label']}</h2>
+      </div>
+      <div class="grid">
+        {cards_html}
+      </div>
+    </section>
+        """)
+
     html = f"""
 <!DOCTYPE html>
-<html lang=\"ru\">
+<html lang="ru">
 <head>
-  <meta charset=\"UTF-8\" />
-  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\" />
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Travel Price Monitor • Выбор направления</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -76,12 +102,33 @@ def generate_landing(tiles, output_file='index.html'):
       display: inline-flex;
       gap: 10px;
       align-items: center;
+      flex-wrap: wrap;
+    }}
+    .filter-section {{
+      margin-top: 24px;
+    }}
+    .section-head {{
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin-bottom: 12px;
+      padding: 0 2px;
+    }}
+    .section-icon {{
+      font-size: 1.35rem;
+      line-height: 1;
+    }}
+    .section-title {{
+      margin: 0;
+      font-size: 1.15rem;
+      font-weight: 800;
+      letter-spacing: .01em;
+      color: #1e293b;
     }}
     .grid {{
       display: grid;
       grid-template-columns: repeat(12, minmax(0, 1fr));
       gap: 16px;
-      margin-top: 22px;
     }}
     .card {{
       grid-column: span 6;
@@ -135,16 +182,14 @@ def generate_landing(tiles, output_file='index.html'):
   </style>
 </head>
 <body>
-  <div class=\"container\">
-    <div class=\"header\">
+  <div class="container">
+    <div class="header">
       <h1>🏨 Travel Price Monitor</h1>
-      <div class=\"subtitle\">Выберите направление • Обновлено: {now}</div>
+      <div class="subtitle">Выберите направление и длительность • Обновлено: {now}</div>
       <div class="meta"><span>🎯 Активных фильтров: {cards_count}</span><span>•</span><span>⏱ Обновление каждый час</span></div>
     </div>
-    <div class=\"grid\">
-      {cards_html}
-    </div>
-    <div class=\"footer\">🤖 Обновляется каждый час • GitHub Pages</div>
+    {''.join(sections_html)}
+    <div class="footer">🤖 Обновляется каждый час • GitHub Pages</div>
   </div>
 </body>
 </html>
@@ -152,9 +197,6 @@ def generate_landing(tiles, output_file='index.html'):
     with open(output_file, 'w', encoding='utf-8') as f:
         f.write(html)
 
+
 if __name__ == '__main__':
-    tiles = [
-        { 'title': 'Фильтр 7–10 дней', 'subtitle': '4766–9000 PLN • WAW/WMI/RDO', 'href': 'index_filter_7_10_days.html' },
-        { 'title': 'Фильтр 13–16 дней', 'subtitle': '4766–9000 PLN • WAW/WMI/RDO', 'href': 'index_filter_13_16_days.html' }
-    ]
-    generate_landing(tiles, 'index.html')
+    generate_landing(FILTER_GROUPS, 'index.html')


### PR DESCRIPTION
Wire CI scrape and dashboard generation for two Turkey filters using the same price and date logic as Egypt. Centralize filter links in filter_registry for landing and sidebar, and gitignore local Turkey scrape outputs.