### PR TITLE
Add Egypt autumn 2026 seasonal filters (7–10 and 13–16 days).

### DIFF
--- a/.github/workflows/travel_monitor_sequential.yml
+++ b/.github/workflows/travel_monitor_sequential.yml
@@ -80,6 +80,8 @@ jobs:
             echo "Mode: sequential (rollback)"
             python travel_monitor.py --config config_ci_filter_7_10.json
             python travel_monitor.py --config config_ci_filter_13_16.json
+            python travel_monitor.py --config config_ci_filter_egypt_autumn_7_10.json
+            python travel_monitor.py --config config_ci_filter_egypt_autumn_13_16.json
             python travel_monitor.py --config config_ci_filter_turkey_7_10.json
             python travel_monitor.py --config config_ci_filter_turkey_9_11.json
             python travel_monitor.py --config config_ci_filter_turkey_vacation_jul18.json
@@ -133,7 +135,7 @@ jobs:
           # (актуальные алерты хранятся в travel_prices_alerts.json, который < 1 MB)
           git add -f data/filters/ || true
           git reset HEAD -- data/price_alerts_history.json "data/filters/"*"/price_alerts_history.json" 2>/dev/null || true
-          git add index.html hotel-chart.html index_filter_7_10_days.html index_filter_13_16_days.html index_filter_turkey_7_10_days.html index_filter_turkey_9_11_days.html index_filter_turkey_vacation_jul18.html index_filter_turkey_13_16_days.html index_filter_greece_7_10_days.html index_filter_greece_13_16_days.html || true
+          git add index.html hotel-chart.html index_filter_7_10_days.html index_filter_13_16_days.html index_filter_egypt_autumn_2026_7_10_days.html index_filter_egypt_autumn_2026_13_16_days.html index_filter_turkey_7_10_days.html index_filter_turkey_9_11_days.html index_filter_turkey_vacation_jul18.html index_filter_turkey_13_16_days.html index_filter_greece_7_10_days.html index_filter_greece_13_16_days.html || true
           # Проверяем размер файлов перед коммитом чтобы поймать проблему заранее
           echo "📏 Файлы >40MB в staging:" && git diff --cached --name-only | xargs -I{} sh -c 'sz=$(git cat-file -s ":{}") 2>/dev/null; [ "$sz" -gt 41943040 ] 2>/dev/null && echo "  $sz bytes: {}" || true' || true
 
@@ -148,9 +150,11 @@ jobs:
             📌 Filters:
             - Egypt 7–10 days (scrape 4000–20000 PLN, show ≤10000)
             - Egypt 13–16 days (scrape 4000–20000 PLN, show ≤10000)
+            - Egypt autumn 2026 7–10 days (10.10–20.11, scrape 0–30000, show ≤15000)
+            - Egypt autumn 2026 13–16 days (10.10–20.11, scrape 0–30000, show ≤15000)
             - Turkey 7–10 days (scrape 4000–20000 PLN, show ≤10000)
             - Turkey 9–11 days (scrape 4610–20000 PLN, show ≤10000)
-            - Turkey vacation Jul 18 (fixed dates, retire 2026-08-14)
+            - Turkey vacation Jul 18 (retired after window)
             - Turkey 13–16 days (scrape 4000–20000 PLN, show ≤10000)
             - Greece 7–10 days (scrape 4000–20000 PLN, show ≤10000)
             - Greece 13–16 days (scrape 4000–20000 PLN, show ≤10000)
@@ -176,9 +180,10 @@ jobs:
           echo "- [Landing](https://andreiYank.github.io/travel-monitoring/)" >> $GITHUB_STEP_SUMMARY
           echo "- [Egypt 7–10 days](https://andreiYank.github.io/travel-monitoring/index_filter_7_10_days.html)" >> $GITHUB_STEP_SUMMARY
           echo "- [Egypt 13–16 days](https://andreiYank.github.io/travel-monitoring/index_filter_13_16_days.html)" >> $GITHUB_STEP_SUMMARY
+          echo "- [Egypt autumn 2026 7–10](https://andreiYank.github.io/travel-monitoring/index_filter_egypt_autumn_2026_7_10_days.html)" >> $GITHUB_STEP_SUMMARY
+          echo "- [Egypt autumn 2026 13–16](https://andreiYank.github.io/travel-monitoring/index_filter_egypt_autumn_2026_13_16_days.html)" >> $GITHUB_STEP_SUMMARY
           echo "- [Turkey 7–10 days](https://andreiYank.github.io/travel-monitoring/index_filter_turkey_7_10_days.html)" >> $GITHUB_STEP_SUMMARY
           echo "- [Turkey 9–11 days](https://andreiYank.github.io/travel-monitoring/index_filter_turkey_9_11_days.html)" >> $GITHUB_STEP_SUMMARY
-          echo "- [Turkey vacation Jul 18](https://andreiYank.github.io/travel-monitoring/index_filter_turkey_vacation_jul18.html)" >> $GITHUB_STEP_SUMMARY
           echo "- [Turkey 13–16 days](https://andreiYank.github.io/travel-monitoring/index_filter_turkey_13_16_days.html)" >> $GITHUB_STEP_SUMMARY
           echo "- [Greece 7–10 days](https://andreiYank.github.io/travel-monitoring/index_filter_greece_7_10_days.html)" >> $GITHUB_STEP_SUMMARY
           echo "- [Greece 13–16 days](https://andreiYank.github.io/travel-monitoring/index_filter_greece_13_16_days.html)" >> $GITHUB_STEP_SUMMARY

--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,12 @@ data/filters/filter_greece_7_10_days/*
 data/filters/filter_greece_13_16_days/*
 !data/filters/filter_greece_13_16_days/archive/
 
+# Local scrape for Egypt autumn 2026 seasonal filters
+data/filters/filter_egypt_autumn_2026_7_10_days/*
+!data/filters/filter_egypt_autumn_2026_7_10_days/archive/
+data/filters/filter_egypt_autumn_2026_13_16_days/*
+!data/filters/filter_egypt_autumn_2026_13_16_days/archive/
+
 
 # Price alerts history — not needed in git (rebuilt each run from CSV)
 # Per-filter alerts (travel_prices_alerts.json) ARE committed — only the legacy global file is excluded

--- a/config_ci_filter_egypt_autumn_13_16.json
+++ b/config_ci_filter_egypt_autumn_13_16.json
@@ -1,0 +1,25 @@
+{
+  "dynamic_search_dates": false,
+  "retire_after": "2026-11-21",
+  "url": "https://fly.pl/oferta/egipt-wczasy/?filter[dest]=11:&filter[hotelids]=&filter[cityids]=&filter[cregids]=&filter[ofrType]=&filter[addObjType]=&filter[whenFrom]=10-10-2026&filter[whenTo]=20-11-2026&filter[duration]=13:16&filter[from]=Warszawa%20-%20Radom,Warszawa,Warszawa%20-%20Modlin&filter[person]=2&filter[child]=1&filter[price]=0:30000&filter[PriceFrom]=0&filter[PriceTo]=30000&filter[addCategory]=50&filter[addCatering]=1&filter[addMisc]=0&filter[addTransport]=F&filter[fp]=1&order_by=ofr_price&filter[tourOperator]=0&filter[childAge][1]=20201210",
+  "max_price_threshold": 30000,
+  "min_price_threshold": 0,
+  "required_offer_url_contains": [
+    "/wycieczka/egipt",
+    "transport=accommodation_flight"
+  ],
+  "excluded_offer_url_contains": [
+    "/wycieczka/polska",
+    "/wycieczka/czechy",
+    "transport=accommodation&"
+  ],
+  "wait_timeout": 30000,
+  "max_retries": 3,
+  "max_offers": 0,
+  "max_pages": 10,
+  "display_price_ceiling": 15000,
+  "retry_delay": 5,
+  "data_dir": "data/filters/filter_egypt_autumn_2026_13_16_days",
+  "output_data_file": "travel_prices.csv",
+  "description": "CI filter • Египет • осень 10.10–20.11.2026 • 13–16 дн. • WAW/WMI/RDO • 2+1 • с питанием • сбор 0–30k, показ ≤15k"
+}

--- a/config_ci_filter_egypt_autumn_7_10.json
+++ b/config_ci_filter_egypt_autumn_7_10.json
@@ -1,0 +1,25 @@
+{
+  "dynamic_search_dates": false,
+  "retire_after": "2026-11-21",
+  "url": "https://fly.pl/oferta/egipt-wczasy/?filter[dest]=11:&filter[hotelids]=&filter[cityids]=&filter[cregids]=&filter[ofrType]=&filter[addObjType]=&filter[whenFrom]=10-10-2026&filter[whenTo]=20-11-2026&filter[duration]=7:10&filter[from]=Warszawa%20-%20Radom,Warszawa,Warszawa%20-%20Modlin&filter[person]=2&filter[child]=1&filter[price]=0:30000&filter[PriceFrom]=0&filter[PriceTo]=30000&filter[addCategory]=50&filter[addCatering]=1&filter[addMisc]=0&filter[addTransport]=F&filter[fp]=1&order_by=ofr_price&filter[tourOperator]=0&filter[childAge][1]=20201210",
+  "max_price_threshold": 30000,
+  "min_price_threshold": 0,
+  "required_offer_url_contains": [
+    "/wycieczka/egipt",
+    "transport=accommodation_flight"
+  ],
+  "excluded_offer_url_contains": [
+    "/wycieczka/polska",
+    "/wycieczka/czechy",
+    "transport=accommodation&"
+  ],
+  "wait_timeout": 30000,
+  "max_retries": 3,
+  "max_offers": 0,
+  "max_pages": 10,
+  "display_price_ceiling": 15000,
+  "retry_delay": 5,
+  "data_dir": "data/filters/filter_egypt_autumn_2026_7_10_days",
+  "output_data_file": "travel_prices.csv",
+  "description": "CI filter • Египет • осень 10.10–20.11.2026 • 7–10 дн. • WAW/WMI/RDO • 2+1 • с питанием • сбор 0–30k, показ ≤15k"
+}

--- a/filter_params.py
+++ b/filter_params.py
@@ -16,6 +16,8 @@ DATA_DIR_CONFIG_FILES: Dict[str, str] = {
     "filter_turkey_9_11_days": "config_ci_filter_turkey_9_11.json",
     "filter_turkey_13_16_days": "config_ci_filter_turkey_13_16.json",
     "filter_turkey_vacation_jul18_2026": "config_ci_filter_turkey_vacation_jul18.json",
+    "filter_egypt_autumn_2026_7_10_days": "config_ci_filter_egypt_autumn_7_10.json",
+    "filter_egypt_autumn_2026_13_16_days": "config_ci_filter_egypt_autumn_13_16.json",
     "filter_greece_7_10_days": "config_ci_filter_greece_7_10.json",
     "filter_greece_13_16_days": "config_ci_filter_greece_13_16.json",
 }

--- a/filter_registry.py
+++ b/filter_registry.py
@@ -22,6 +22,22 @@ FILTER_GROUPS = [
                 'charts_subdir': 'hotel-charts/filter_turkey_vacation_jul18_2026',
                 'config': 'config_ci_filter_turkey_vacation_jul18.json',
             },
+            {
+                'id': 'egypt_autumn_2026_7_10',
+                'title': 'Египет • осень 2026 • 7–10 дн.',
+                'subtitle': '10.10–20.11.2026 • WAW/WMI/RDO • 2+1 • показ ≤15k',
+                'href': 'index_filter_egypt_autumn_2026_7_10_days.html',
+                'charts_subdir': 'hotel-charts/filter_egypt_autumn_2026_7_10_days',
+                'config': 'config_ci_filter_egypt_autumn_7_10.json',
+            },
+            {
+                'id': 'egypt_autumn_2026_13_16',
+                'title': 'Египет • осень 2026 • 13–16 дн.',
+                'subtitle': '10.10–20.11.2026 • WAW/WMI/RDO • 2+1 • показ ≤15k',
+                'href': 'index_filter_egypt_autumn_2026_13_16_days.html',
+                'charts_subdir': 'hotel-charts/filter_egypt_autumn_2026_13_16_days',
+                'config': 'config_ci_filter_egypt_autumn_13_16.json',
+            },
         ],
     },
     {

--- a/scripts/run_dashboards_parallel.py
+++ b/scripts/run_dashboards_parallel.py
@@ -32,6 +32,26 @@ DEFAULT_DASHBOARDS = [
         "alerts": "data/filters/filter_13_16_days/travel_prices_alerts.json",
     },
     {
+        "data": "data/filters/filter_egypt_autumn_2026_7_10_days/travel_prices.csv",
+        "output": "index_filter_egypt_autumn_2026_7_10_days.html",
+        "title": "Мониторинг цен • Египет • осень 2026 • 7–10 дней",
+        "charts": "hotel-charts/filter_egypt_autumn_2026_7_10_days",
+        "alerts": "data/filters/filter_egypt_autumn_2026_7_10_days/travel_prices_alerts.json",
+        "config": "config_ci_filter_egypt_autumn_7_10.json",
+        "display_price_ceiling": "15000",
+        "history_price_ceiling": "30000",
+    },
+    {
+        "data": "data/filters/filter_egypt_autumn_2026_13_16_days/travel_prices.csv",
+        "output": "index_filter_egypt_autumn_2026_13_16_days.html",
+        "title": "Мониторинг цен • Египет • осень 2026 • 13–16 дней",
+        "charts": "hotel-charts/filter_egypt_autumn_2026_13_16_days",
+        "alerts": "data/filters/filter_egypt_autumn_2026_13_16_days/travel_prices_alerts.json",
+        "config": "config_ci_filter_egypt_autumn_13_16.json",
+        "display_price_ceiling": "15000",
+        "history_price_ceiling": "30000",
+    },
+    {
         "data": "data/filters/filter_turkey_7_10_days/travel_prices.csv",
         "output": "index_filter_turkey_7_10_days.html",
         "title": "Мониторинг цен • Турция • 7–10 дней",
@@ -103,9 +123,9 @@ def _run_one(spec: dict, log_dir: Path) -> tuple[str, int, float, str]:
         "--alerts-file",
         spec["alerts"],
         "--display-price-ceiling",
-        "10000",
+        str(spec.get("display_price_ceiling", "10000")),
         "--history-price-ceiling",
-        "20000",
+        str(spec.get("history_price_ceiling", "20000")),
     ]
     if spec.get("config"):
         cmd.extend(["--config-file", spec["config"]])

--- a/scripts/run_monitors_parallel.py
+++ b/scripts/run_monitors_parallel.py
@@ -19,6 +19,8 @@ from filter_trip import load_config_json, should_skip_monitor_config, skip_monit
 DEFAULT_CONFIGS = [
     "config_ci_filter_7_10.json",
     "config_ci_filter_13_16.json",
+    "config_ci_filter_egypt_autumn_7_10.json",
+    "config_ci_filter_egypt_autumn_13_16.json",
     "config_ci_filter_turkey_7_10.json",
     "config_ci_filter_turkey_9_11.json",
     "config_ci_filter_turkey_vacation_jul18.json",


### PR DESCRIPTION
Fixed search window 10.10–20.11.2026 with WAW/WMI/RDO, wired into CI monitors, dashboards, landing, and Pages.